### PR TITLE
fix(jsonapi): permitir deserialización genérica en JsonApiDocument y …

### DIFF
--- a/products-application/products-commons/src/main/java/co/com/linktic/commons/dto/JsonApiDocument.java
+++ b/products-application/products-commons/src/main/java/co/com/linktic/commons/dto/JsonApiDocument.java
@@ -1,16 +1,15 @@
 package co.com.linktic.commons.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class JsonApiDocument<T> {
-	private final JsonApiResponse<T> data;
 
-	public JsonApiDocument(JsonApiResponse<T> data) {
-		this.data = data;
-	}
+	private JsonApiResponse<T> data;
 
-	public JsonApiResponse<T> getData() {
-		return data;
-	}
+
 }

--- a/products-application/products-commons/src/main/java/co/com/linktic/commons/dto/JsonApiPagedResponse.java
+++ b/products-application/products-commons/src/main/java/co/com/linktic/commons/dto/JsonApiPagedResponse.java
@@ -8,8 +8,8 @@ public class JsonApiPagedResponse<T> implements Serializable {
 
 	private static final long serialVersionUID = -519354209251487874L;
 
-	private final List<JsonApiResponse<T>> data;
-	private final Map<String, Object> meta;
+	private List<JsonApiResponse<T>> data;
+	private Map<String, Object> meta;
 
 	public JsonApiPagedResponse(List<JsonApiResponse<T>> data, int totalPages, long totalElements, int size,
 			int number) {

--- a/products-application/products-commons/src/main/java/co/com/linktic/commons/dto/JsonApiResponse.java
+++ b/products-application/products-commons/src/main/java/co/com/linktic/commons/dto/JsonApiResponse.java
@@ -2,16 +2,20 @@ package co.com.linktic.commons.dto;
 
 import java.io.Serializable;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class JsonApiResponse<T> implements Serializable {
 
 	private static final long serialVersionUID = 7182246982151547214L;
 
-	private final String type;
-	private final String id;
-	private final T attributes;
+	private String type;
+	private String id;
+	private T attributes;
 
 	public JsonApiResponse(String id, T attributes) {
 		this.type = "product";


### PR DESCRIPTION
Se agregaron constructores sin argumentos y se eliminaron los campos final en las clases JsonApiDocument y JsonApiResponse para permitir la correcta deserialización de objetos genéricos por parte de Jackson, especialmente al usarse con RestTemplate.