### PR TITLE
feat(inventory): retornar respuesta en formato JSON:API al actualizar o vender inventario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.db
+products-application/sonar-project.properties

--- a/inventory-application/.gitignore
+++ b/inventory-application/.gitignore
@@ -1,0 +1,201 @@
+/target/
+!.mvn/wrapper/maven-wrapper.jar
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+
+# Created by https://www.gitignore.io/api/git,java,maven,eclipse,windows
+
+### Eclipse ###
+
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+### Eclipse Patch ###
+# Eclipse Core
+.project
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Annotation Processing
+.apt_generated
+
+.sts4-cache/
+
+### Git ###
+# Created by git for backups. To disable backups in Git:
+# $ git config --global mergetool.keepBackup false
+*.orig
+
+# Created by git when using merge tools for conflicts
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*_BACKUP_*.txt
+*_BASE_*.txt
+*_LOCAL_*.txt
+*_REMOTE_*.txt
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+### Maven ###
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Some additional ignores (sort later)
+*.DS_Store
+*.sw?
+.#*
+*#
+*~
+.classpath
+.project
+.settings
+bin
+build
+target
+dependency-reduced-pom.xml
+*.sublime-*
+/scratch
+.gradle
+README.html
+*.iml
+.idea
+.exercism

--- a/inventory-application/inventory-commons/pom.xml
+++ b/inventory-application/inventory-commons/pom.xml
@@ -1,8 +1,29 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>co.com.linktic</groupId>
-  <artifactId>inventory-commons</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
-  <name>inventory-commons</name>
-  <description>Proyecto que contiene los objectos comunes para el manejo de inventario</description>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>co.com.linktic</groupId>
+	<artifactId>inventory-commons</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<name>inventory-commons</name>
+	<description>Proyecto que contiene los objectos comunes para el manejo de inventario</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.38</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>3.0-rc5</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.1.1</version>
+		</dependency>
+	</dependencies>
 </project>

--- a/inventory-application/inventory-commons/pom.xml
+++ b/inventory-application/inventory-commons/pom.xml
@@ -1,0 +1,8 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>co.com.linktic</groupId>
+  <artifactId>inventory-commons</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <name>inventory-commons</name>
+  <description>Proyecto que contiene los objectos comunes para el manejo de inventario</description>
+</project>

--- a/inventory-application/inventory-commons/src/main/java/co/com/linktic/commons/domain/data/MovementType.java
+++ b/inventory-application/inventory-commons/src/main/java/co/com/linktic/commons/domain/data/MovementType.java
@@ -1,0 +1,7 @@
+package co.com.linktic.commons.domain.data;
+
+public enum MovementType {
+
+	PURCHASE, SALE, ADJUSTMENT
+
+}

--- a/inventory-application/inventory-commons/src/main/java/co/com/linktic/commons/domain/exception/InsufficientStockException.java
+++ b/inventory-application/inventory-commons/src/main/java/co/com/linktic/commons/domain/exception/InsufficientStockException.java
@@ -1,0 +1,12 @@
+package co.com.linktic.commons.domain.exception;
+
+public class InsufficientStockException extends RuntimeException {
+
+	private static final long serialVersionUID = -8803097577796424210L;
+
+	public InsufficientStockException(Long productId, int requested, int available) {
+		super("Inventario insuficiente para el producto " + productId + ": solicitado " + requested + ", disponible "
+				+ available);
+	}
+
+}

--- a/inventory-application/inventory-commons/src/main/java/co/com/linktic/commons/domain/exception/JsonApiError.java
+++ b/inventory-application/inventory-commons/src/main/java/co/com/linktic/commons/domain/exception/JsonApiError.java
@@ -1,0 +1,14 @@
+package co.com.linktic.commons.domain.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class JsonApiError {
+
+	private String status;
+	private String title;
+	private String detail;
+
+}

--- a/inventory-application/inventory-commons/src/main/java/co/com/linktic/commons/dto/InventoryDTO.java
+++ b/inventory-application/inventory-commons/src/main/java/co/com/linktic/commons/dto/InventoryDTO.java
@@ -1,0 +1,18 @@
+package co.com.linktic.commons.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class InventoryDTO {
+
+	private Long productId;
+	private int availableStock;
+	private LocalDateTime updatedAt;
+
+}

--- a/inventory-application/inventory-commons/src/main/java/co/com/linktic/commons/dto/PurchaseRequest.java
+++ b/inventory-application/inventory-commons/src/main/java/co/com/linktic/commons/dto/PurchaseRequest.java
@@ -1,0 +1,18 @@
+package co.com.linktic.commons.dto;
+
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PurchaseRequest {
+
+	private Long productId;
+
+	@Positive(message = "La cantidad debe ser mayor que cero")
+	private int quantity;
+
+}

--- a/inventory-application/inventory-services/.gitattributes
+++ b/inventory-application/inventory-services/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/inventory-application/inventory-services/.gitignore
+++ b/inventory-application/inventory-services/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/inventory-application/inventory-services/pom.xml
+++ b/inventory-application/inventory-services/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.5.3</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>co.com.linktic</groupId>
+	<artifactId>inventory-services</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<name>inventory-services</name>
+	<description>Proyecto que contiene los servicios del inventario</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/inventory-application/inventory-services/pom.xml
+++ b/inventory-application/inventory-services/pom.xml
@@ -1,46 +1,88 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.3</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
+
 	<groupId>co.com.linktic</groupId>
 	<artifactId>inventory-services</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<name>inventory-services</name>
 	<description>Proyecto que contiene los servicios del inventario</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
+
 	<properties>
 		<java.version>17</java.version>
 	</properties>
 	<dependencies>
+
+		<!-- database dependecies -->
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 
+		<!-- web dependecies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<!-- devtools dependecies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.modelmapper</groupId>
+			<artifactId>modelmapper</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+
+		<!-- swagger dependecies -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.8</version>
+		</dependency>
+
+		<!-- local dependecies -->
+		<dependency>
+			<groupId>co.com.linktic</groupId>
+			<artifactId>products-commons</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>co.com.linktic</groupId>
+			<artifactId>inventory-commons</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
+		</dependency>
+
+		<!-- test dependecies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
 
 	<build>
 		<plugins>

--- a/inventory-application/inventory-services/src/main/java/co/com/linktic/services/InventoryServicesApplication.java
+++ b/inventory-application/inventory-services/src/main/java/co/com/linktic/services/InventoryServicesApplication.java
@@ -1,0 +1,13 @@
+package co.com.linktic.services;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class InventoryServicesApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(InventoryServicesApplication.class, args);
+	}
+
+}

--- a/inventory-application/inventory-services/src/main/java/co/com/linktic/services/config/AppConfig.java
+++ b/inventory-application/inventory-services/src/main/java/co/com/linktic/services/config/AppConfig.java
@@ -1,0 +1,15 @@
+package co.com.linktic.services.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+
+	@Bean
+	ModelMapper mapper() {
+		return new ModelMapper();
+	}
+
+}

--- a/inventory-application/inventory-services/src/main/java/co/com/linktic/services/config/RestTemplateConfig.java
+++ b/inventory-application/inventory-services/src/main/java/co/com/linktic/services/config/RestTemplateConfig.java
@@ -1,0 +1,26 @@
+package co.com.linktic.services.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+	@Value("${security.product.api-key}")
+	private String apiKey;
+
+	@Bean
+	RestTemplate restTemplate() {
+		var restTemplate = new RestTemplate();
+
+		restTemplate.getInterceptors().add((request, body, execution) -> {
+			request.getHeaders().add("x-api-key", apiKey);
+			return execution.execute(request, body);
+		});
+
+		return restTemplate;
+	}
+
+}

--- a/inventory-application/inventory-services/src/main/java/co/com/linktic/services/controller/InventoryController.java
+++ b/inventory-application/inventory-services/src/main/java/co/com/linktic/services/controller/InventoryController.java
@@ -1,0 +1,43 @@
+package co.com.linktic.services.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import co.com.linktic.commons.dto.InventoryDTO;
+import co.com.linktic.commons.dto.JsonApiDocument;
+import co.com.linktic.commons.dto.PurchaseRequest;
+import co.com.linktic.services.services.InventoryService;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/v1/inventory")
+public class InventoryController {
+
+	private final InventoryService inventoryService;
+
+	/**
+	 * Registra una compra y actualiza el stock sumando la cantidad comprada.
+	 *
+	 * @param request objeto con productId y quantity
+	 */
+	@PostMapping("/purchase")
+	public ResponseEntity<JsonApiDocument<InventoryDTO>> purchase(@RequestBody @Valid PurchaseRequest request) {
+		return ResponseEntity.ok(inventoryService.purchase(request));
+	}
+
+	@PutMapping("/{productId}/stock")
+	public ResponseEntity<JsonApiDocument<InventoryDTO>> updateStock(@PathVariable Long productId,
+			@RequestParam int quantity) {
+		return ResponseEntity.ok(inventoryService.updateStock(productId, quantity));
+	}
+
+
+}

--- a/inventory-application/inventory-services/src/main/java/co/com/linktic/services/entity/Inventory.java
+++ b/inventory-application/inventory-services/src/main/java/co/com/linktic/services/entity/Inventory.java
@@ -1,0 +1,39 @@
+package co.com.linktic.services.entity;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@Table(name = "inventory")
+public class Inventory implements Serializable {
+
+	private static final long serialVersionUID = 7473785574571080933L;
+
+	@Id
+	private Long productId; // ID del producto
+
+	private int availableStock;
+
+	private LocalDateTime updatedAt;
+
+	@PreUpdate
+	@PrePersist
+	public void updateTimestamp() {
+		this.updatedAt = LocalDateTime.now();
+	}
+
+}

--- a/inventory-application/inventory-services/src/main/java/co/com/linktic/services/entity/StockMovement.java
+++ b/inventory-application/inventory-services/src/main/java/co/com/linktic/services/entity/StockMovement.java
@@ -1,0 +1,47 @@
+package co.com.linktic.services.entity;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import co.com.linktic.commons.domain.data.MovementType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "stock_movements")
+public class StockMovement implements Serializable {
+
+	private static final long serialVersionUID = -8155227866100054012L;
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private Long productId;
+
+	private int quantityChange;
+
+	@Enumerated(EnumType.STRING)
+	private MovementType movementType;
+
+	private LocalDateTime timestamp;
+
+	@PrePersist
+	public void prePersist() {
+		this.timestamp = LocalDateTime.now();
+	}
+}

--- a/inventory-application/inventory-services/src/main/java/co/com/linktic/services/handler/GlobalExceptionHandler.java
+++ b/inventory-application/inventory-services/src/main/java/co/com/linktic/services/handler/GlobalExceptionHandler.java
@@ -1,0 +1,76 @@
+package co.com.linktic.services.handler;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import co.com.linktic.commons.domain.exception.InsufficientStockException;
+import co.com.linktic.commons.domain.exception.JsonApiError;
+import co.com.linktic.commons.exception.domain.ProductNotFound;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(ProductNotFound.class)
+	public ResponseEntity<Map<String, Object>> handleProductNotFound(ProductNotFound ex) {
+		log.warn("Producto no encontrado: {}", ex.getMessage());
+
+		var error = new JsonApiError("404", "Producto no encontrado",
+				"El producto especificado no existe en el sistema");
+
+		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("errors", List.of(error)));
+	}
+
+	@ExceptionHandler(InsufficientStockException.class)
+	public ResponseEntity<Map<String, Object>> handleInsufficientStock(InsufficientStockException ex) {
+		log.warn("Stock insuficiente: {}", ex.getMessage());
+
+		var error = new JsonApiError("400", "Stock insuficiente", ex.getMessage());
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("errors", List.of(error)));
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<Map<String, Object>> handleValidationErrors(MethodArgumentNotValidException ex) {
+		var errors = ex.getBindingResult().getFieldErrors().stream().map(
+				err -> new JsonApiError("400", "Validación fallida", err.getField() + ": " + err.getDefaultMessage()))
+				.toList();
+
+		return ResponseEntity.badRequest().body(Map.of("errors", errors));
+	}
+
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ResponseEntity<Map<String, Object>> handleConstraintViolation(ConstraintViolationException ex) {
+		var errors = ex.getConstraintViolations().stream().map(err -> new JsonApiError("400",
+				"Violación de restricción", err.getPropertyPath() + ": " + err.getMessage())).toList();
+
+		return ResponseEntity.badRequest().body(Map.of("errors", errors));
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<Map<String, Object>> handleIllegalArgument(IllegalArgumentException ex) {
+		log.warn("Parámetro inválido: {}", ex.getMessage());
+
+		var error = new JsonApiError("400", "Solicitud inválida", ex.getMessage());
+
+		return ResponseEntity.badRequest().body(Map.of("errors", List.of(error)));
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<Map<String, Object>> handleGenericException(Exception ex) {
+		log.error("Error inesperado: {}", ex.getMessage(), ex);
+
+		var error = new JsonApiError("500", "Error interno del servidor",
+				"Ocurrió un error inesperado. Inténtalo más tarde.");
+
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("errors", List.of(error)));
+	}
+}

--- a/inventory-application/inventory-services/src/main/java/co/com/linktic/services/repository/InventoryRepository.java
+++ b/inventory-application/inventory-services/src/main/java/co/com/linktic/services/repository/InventoryRepository.java
@@ -1,0 +1,9 @@
+package co.com.linktic.services.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import co.com.linktic.services.entity.Inventory;
+
+public interface InventoryRepository extends JpaRepository<Inventory, Long> {
+
+}

--- a/inventory-application/inventory-services/src/main/java/co/com/linktic/services/rest/client/ProductRestClient.java
+++ b/inventory-application/inventory-services/src/main/java/co/com/linktic/services/rest/client/ProductRestClient.java
@@ -1,0 +1,54 @@
+package co.com.linktic.services.rest.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import co.com.linktic.commons.dto.JsonApiDocument;
+import co.com.linktic.commons.dto.ProductDTO;
+import co.com.linktic.commons.exception.domain.ProductNotFound;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class ProductRestClient {
+
+	@Value("${products.base-url}")
+	private String baseUrl;
+
+	private RestTemplate restTemplate;
+
+	public ProductRestClient(RestTemplate restTemplate) {
+		this.restTemplate = restTemplate;
+	}
+
+	public ProductDTO findById(Long id) {
+
+		log.info("Buscando el producto {}", id);
+
+		var url = baseUrl + id;
+		log.info("url: {}", url);
+
+		try {
+
+			ResponseEntity<JsonApiDocument<ProductDTO>> response = restTemplate.exchange(url, HttpMethod.GET, null,
+					new ParameterizedTypeReference<JsonApiDocument<ProductDTO>>() {
+					});
+
+			var body = response.getBody();
+
+			if (response.getStatusCode().is2xxSuccessful() && body != null && body.getData() != null) {
+				return body.getData().getAttributes();
+			}
+			throw new ProductNotFound();
+
+		} catch (Exception e) {
+			log.error("Error al consultar producto {}: {}", id, e.getMessage());
+			throw new ProductNotFound();
+		}
+	}
+
+}

--- a/inventory-application/inventory-services/src/main/java/co/com/linktic/services/rest/client/StockMovementRepository.java
+++ b/inventory-application/inventory-services/src/main/java/co/com/linktic/services/rest/client/StockMovementRepository.java
@@ -1,0 +1,9 @@
+package co.com.linktic.services.rest.client;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import co.com.linktic.services.entity.StockMovement;
+
+public interface StockMovementRepository extends JpaRepository<StockMovement, Long> {
+
+}

--- a/inventory-application/inventory-services/src/main/java/co/com/linktic/services/services/InventoryService.java
+++ b/inventory-application/inventory-services/src/main/java/co/com/linktic/services/services/InventoryService.java
@@ -1,0 +1,47 @@
+package co.com.linktic.services.services;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+
+import co.com.linktic.services.entity.Inventory;
+import co.com.linktic.services.repository.InventoryRepository;
+import co.com.linktic.services.rest.client.ProductRestClient;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class InventoryService {
+
+	private final InventoryRepository inventoryRepository;
+	private final ProductRestClient productoRestClient;
+
+	public void updateStock(Long productId, int newQuantity) {
+
+		log.info("Inicia actualizacion el stock del producto {} a {} unidades", productId, newQuantity);
+
+		// Verifica que el producto exista
+		productoRestClient.findById(productId);
+
+		// Validar que el stock no sea negativo
+		if (newQuantity < 0) {
+			log.warn("Stock negativo no permitido: producto {} con cantidad {}", productId, newQuantity);
+			throw new IllegalArgumentException("La cantidad disponible no puede ser negativa");
+		}
+
+		// Buscar inventario local o crear uno nuevo
+		var inventory = inventoryRepository.findById(productId).orElse(new Inventory(productId, 0, null));
+
+		// Actualizar el stock
+		inventory.setAvailableStock(newQuantity);
+		inventory.setUpdatedAt(LocalDateTime.now());
+
+		inventoryRepository.save(inventory);
+
+		log.info("Inventario actualizado correctamente para producto {}: {} unidades, inventario: {}", productId,
+				newQuantity, inventory);
+
+	}
+}

--- a/inventory-application/inventory-services/src/main/java/co/com/linktic/services/services/InventoryService.java
+++ b/inventory-application/inventory-services/src/main/java/co/com/linktic/services/services/InventoryService.java
@@ -2,11 +2,20 @@ package co.com.linktic.services.services;
 
 import java.time.LocalDateTime;
 
+import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import co.com.linktic.commons.domain.data.MovementType;
+import co.com.linktic.commons.domain.exception.InsufficientStockException;
+import co.com.linktic.commons.dto.InventoryDTO;
+import co.com.linktic.commons.dto.JsonApiDocument;
+import co.com.linktic.commons.dto.JsonApiResponse;
+import co.com.linktic.commons.dto.PurchaseRequest;
 import co.com.linktic.services.entity.Inventory;
+import co.com.linktic.services.entity.StockMovement;
 import co.com.linktic.services.repository.InventoryRepository;
 import co.com.linktic.services.rest.client.ProductRestClient;
+import co.com.linktic.services.rest.client.StockMovementRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -15,33 +24,71 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 public class InventoryService {
 
-	private final InventoryRepository inventoryRepository;
 	private final ProductRestClient productoRestClient;
+	private final InventoryRepository inventoryRepository;
+	private final StockMovementRepository stockMovementRepository;
+	private final ModelMapper mapper;
 
-	public void updateStock(Long productId, int newQuantity) {
+	/**
+	 * Realiza una venta: descuenta del stock y registra movimiento
+	 *
+	 * @param request objeto con productId y cantidad
+	 * @return Inventario actualizado como JSON:API
+	 */
+	public JsonApiDocument<InventoryDTO> purchase(PurchaseRequest request) {
+		log.info("Registrando venta: producto {} - cantidad {}", request.getProductId(), request.getQuantity());
 
-		log.info("Inicia actualizacion el stock del producto {} a {} unidades", productId, newQuantity);
+		productoRestClient.findById(request.getProductId());
 
-		// Verifica que el producto exista
-		productoRestClient.findById(productId);
+		var inventory = inventoryRepository.findById(request.getProductId())
+				.orElseThrow(() -> new IllegalStateException("El inventario del producto no existe"));
 
-		// Validar que el stock no sea negativo
-		if (newQuantity < 0) {
-			log.warn("Stock negativo no permitido: producto {} con cantidad {}", productId, newQuantity);
-			throw new IllegalArgumentException("La cantidad disponible no puede ser negativa");
+		var stockActual = inventory.getAvailableStock();
+
+		if (stockActual < request.getQuantity()) {
+			log.warn("Stock insuficiente: producto {}, disponible {}, solicitado {}", request.getProductId(),
+					stockActual, request.getQuantity());
+			throw new InsufficientStockException(request.getProductId(), request.getQuantity(), stockActual);
 		}
 
-		// Buscar inventario local o crear uno nuevo
-		var inventory = inventoryRepository.findById(productId).orElse(new Inventory(productId, 0, null));
-
-		// Actualizar el stock
-		inventory.setAvailableStock(newQuantity);
+		var nuevoStock = stockActual - request.getQuantity();
+		inventory.setAvailableStock(nuevoStock);
 		inventory.setUpdatedAt(LocalDateTime.now());
-
 		inventoryRepository.save(inventory);
 
-		log.info("Inventario actualizado correctamente para producto {}: {} unidades, inventario: {}", productId,
-				newQuantity, inventory);
+		stockMovementRepository.save(StockMovement.builder().productId(request.getProductId())
+				.quantityChange(-request.getQuantity()).movementType(MovementType.SALE).build());
 
+		log.info("Venta registrada: producto {}, nuevo stock: {}", request.getProductId(), nuevoStock);
+
+		return toJsonApi(inventory);
+	}
+
+	/**
+	 * Actualiza directamente la cantidad de stock
+	 *
+	 * @param productId   ID del producto
+	 * @param newQuantity nueva cantidad disponible
+	 * @return Inventario actualizado como JSON:API
+	 */
+	public JsonApiDocument<InventoryDTO> updateStock(Long productId, int newQuantity) {
+		productoRestClient.findById(productId);
+
+		var inventory = inventoryRepository.findById(productId).orElse(new Inventory(productId, 0, null));
+
+		inventory.setAvailableStock(newQuantity);
+		inventory.setUpdatedAt(LocalDateTime.now());
+		inventoryRepository.save(inventory);
+
+		return toJsonApi(inventory);
+	}
+
+	/**
+	 * Convierte entidad Inventory a JsonApiDocument<InventoryDTO>
+	 */
+	private JsonApiDocument<InventoryDTO> toJsonApi(Inventory inventory) {
+		var dto = mapper.map(inventory, InventoryDTO.class);
+		var response = new JsonApiResponse<>("inventory", String.valueOf(dto.getProductId()), dto);
+		return new JsonApiDocument<>(response);
 	}
 }

--- a/inventory-application/inventory-services/src/main/resources/application.properties
+++ b/inventory-application/inventory-services/src/main/resources/application.properties
@@ -1,1 +1,26 @@
 spring.application.name=inventory-services
+server.port=8081
+
+products.base-url=http://localhost:8080/api/v1/product/
+security.product.api-key=${secret-product-api-key}
+
+# ==============================
+# Configuracion H2 + Spring Boot
+# ==============================
+
+# URL de conexion a base de datos en memoria
+spring.datasource.password=
+spring.datasource.username=sa
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.datasource.url=jdbc:h2:file:./data/testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+
+# Mostrar consultas SQL en consola
+spring.jpa.show-sql=true
+
+# Crear tablas
+spring.jpa.hibernate.ddl-auto=update
+
+# Activar la consola
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console

--- a/inventory-application/inventory-services/src/main/resources/application.properties
+++ b/inventory-application/inventory-services/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=inventory-services

--- a/inventory-application/inventory-services/src/test/java/co/com/linktic/services/InventoryServicesApplicationTests.java
+++ b/inventory-application/inventory-services/src/test/java/co/com/linktic/services/InventoryServicesApplicationTests.java
@@ -1,0 +1,13 @@
+package co.com.linktic.services;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class InventoryServicesApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/inventory-application/pom.xml
+++ b/inventory-application/pom.xml
@@ -1,0 +1,9 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>co.com.linktic</groupId>
+  <artifactId>inventory-application</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>inventory-application</name>
+  <description>Aplicacion que contiene todos los proyectos necesarios para el manejo de inventario</description>
+</project>

--- a/inventory-application/pom.xml
+++ b/inventory-application/pom.xml
@@ -1,9 +1,16 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>co.com.linktic</groupId>
-  <artifactId>inventory-application</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
-  <packaging>pom</packaging>
-  <name>inventory-application</name>
-  <description>Aplicacion que contiene todos los proyectos necesarios para el manejo de inventario</description>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>co.com.linktic</groupId>
+	<artifactId>inventory-application</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<name>inventory-application</name>
+	<description>Aplicacion que contiene todos los proyectos necesarios para el
+		manejo de inventario</description>
+	<modules>
+		<module>inventory-commons</module>
+		<module>inventory-services</module>
+	</modules>
 </project>


### PR DESCRIPTION
Se actualizó la lógica del servicio de inventario (InventoryService) para retornar respuestas compatibles con el estándar JSON:API.

Cambios incluidos:
Se reemplazaron los métodos void por respuestas JsonApiDocument<InventoryDTO>.

Se agregó el DTO InventoryDTO para estructurar la respuesta.

Se utilizó JsonApiResponse y JsonApiDocument como en el microservicio de productos.

Se adaptó el controlador InventoryController para devolver la respuesta estructurada.

Formato de respuesta esperado:
json
Copiar
Editar
{
  "data": {
    "type": "inventory",
    "id": "1",
    "attributes": {
      "productId": 1,
      "availableStock": 80,
      "updatedAt": "2025-07-18T23:52:00"
    }
  }
}