### PR TITLE
feat(security): agregar autenticación por API Key para proteger los endpoints del servicio de inventario

### DIFF
--- a/inventory-application/inventory-services/pom.xml
+++ b/inventory-application/inventory-services/pom.xml
@@ -38,6 +38,12 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
+		<!--security dependecies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
 		<!-- devtools dependecies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/inventory-application/inventory-services/src/main/java/co/com/linktic/services/config/SecurityConfig.java
+++ b/inventory-application/inventory-services/src/main/java/co/com/linktic/services/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package co.com.linktic.services.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import co.com.linktic.services.filter.ApiKeyAuthFilter;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final ApiKeyAuthFilter apiKeyAuthFilter;
+
+	@Bean
+	SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		return http
+				.authorizeHttpRequests(
+						auth -> auth.requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**",
+								"/webjars/**", "/h2-console/**").permitAll().anyRequest().authenticated())
+				.csrf(CsrfConfigurer::disable).headers(headers -> headers.frameOptions(FrameOptionsConfig::disable))
+				.addFilterBefore(apiKeyAuthFilter, UsernamePasswordAuthenticationFilter.class).build();
+	}
+}

--- a/inventory-application/inventory-services/src/main/java/co/com/linktic/services/config/SwaggerSecurityConfig.java
+++ b/inventory-application/inventory-services/src/main/java/co/com/linktic/services/config/SwaggerSecurityConfig.java
@@ -1,0 +1,20 @@
+package co.com.linktic.services.config;
+
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+
+/**
+ * Configuración de OpenAPI para integrar la autenticación por API Key en Swagger UI. Define un esquema de seguridad para 'x-api-key' en el header y lo aplica globalmente.
+ */
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "Mi API", version = "1.0", description = "Documentación de la API con autenticación por API Key"), security = @SecurityRequirement(name = "apiKey"))
+@SecurityScheme(name = "apiKey", type = SecuritySchemeType.APIKEY, in = SecuritySchemeIn.HEADER, paramName = "x-api-key", description = "Requiere una API Key válida en el encabezado 'x-api-key' para acceder a los servicios.")
+public class SwaggerSecurityConfig {
+
+}

--- a/inventory-application/inventory-services/src/main/java/co/com/linktic/services/filter/ApiKeyAuthFilter.java
+++ b/inventory-application/inventory-services/src/main/java/co/com/linktic/services/filter/ApiKeyAuthFilter.java
@@ -1,0 +1,53 @@
+package co.com.linktic.services.filter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class ApiKeyAuthFilter extends OncePerRequestFilter {
+
+	@Value("${security.api-key}")
+	private String validApiKey;
+
+	private static final List<String> EXCLUDED_PATHS = List.of("/swagger-ui", "/v3/api-docs", "/swagger-resources",
+			"/webjars", "/h2-console", "/actuator");
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		var path = request.getRequestURI();
+		return EXCLUDED_PATHS.stream().anyMatch(path::startsWith);
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+
+		var header = request.getHeader("x-api-key");
+
+		if (header == null || !header.equals(validApiKey)) {
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			response.getWriter().write("API key invalida");
+			return;
+		}
+
+		// Autenticar manualmente al usuario autenticado
+		var authentication = new UsernamePasswordAuthenticationToken("apikey-user", null, Collections.emptyList());
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		filterChain.doFilter(request, response);
+	}
+}

--- a/inventory-application/inventory-services/src/main/resources/application.properties
+++ b/inventory-application/inventory-services/src/main/resources/application.properties
@@ -3,6 +3,7 @@ server.port=8081
 
 products.base-url=http://localhost:8080/api/v1/product/
 security.product.api-key=${secret-product-api-key}
+security.api-key=${security.api-key}
 
 # ==============================
 # Configuracion H2 + Spring Boot


### PR DESCRIPTION
Se implementó la validación de API Key para proteger el acceso a los endpoints del servicio de inventario, siguiendo buenas prácticas de seguridad.

Cambios realizados:
Se creó la clase ApiKeyAuthFilter que valida la cabecera x-api-key en cada solicitud.

Se excluyeron rutas públicas como Swagger, H2 Console y actuator.

Se ajustó la clase SecurityConfig para usar el filtro y permitir esas rutas sin autenticación.

Se simula un usuario autenticado al pasar la validación de la API Key, evitando respuestas 403 de Spring Security.

API Key esperada:
Se debe enviar en cada solicitud protegida:

x-api-key: secret-key-inventory-123

Ejemplo de llamada:
GET /api/v1/inventory/1/stock
x-api-key: secret-key-inventory-123