### PR TITLE
chore(docker): agregar configuración Docker y archivo .env para entorno local

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+SECURITY_API_KEY=secret-key-inventory-123
+PRODUCT_API_KEY=secret-key-products-asdfg
+PRODUCTS_BASE_URL=http://products-service:8080/api/v1/product

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+
+services:
+  products-service:
+    build:
+      context: ./products-application/products-services
+    ports:
+      - "8080:8080"
+    environment:
+      - SECURITY_API_KEY=${PRODUCT_API_KEY}
+
+  inventory-service:
+    build:
+      context: ./inventory-application/inventory-services
+    ports:
+      - "8081:8081"
+    environment:
+      - SECURITY_API_KEY=${SECURITY_API_KEY}
+      - PRODUCT_API_KEY=${PRODUCT_API_KEY}
+    depends_on:
+      - products-service

--- a/inventory-application/inventory-services/Dockerfile
+++ b/inventory-application/inventory-services/Dockerfile
@@ -1,0 +1,10 @@
+# Dockerfile
+FROM eclipse-temurin:17-jdk-alpine
+
+WORKDIR /app
+
+COPY target/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/products-application/products-services/Dockerfile
+++ b/products-application/products-services/Dockerfile
@@ -1,0 +1,10 @@
+# Dockerfile
+FROM eclipse-temurin:17-jdk-alpine
+
+WORKDIR /app
+
+COPY target/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
Se agrega la configuración necesaria para ejecutar ambos microservicios (products-services e inventory-services) mediante Docker y Docker Compose.

Archivos agregados:
Dockerfile para cada microservicio

docker-compose.yml para levantar los servicios de forma orquestada

.env con las variables necesarias para autenticación por API Key y consumo de servicios

Variables manejadas:
SECURITY_API_KEY

PRODUCT_API_KEY

PRODUCTS_BASE_URL

Notas:
No se requiere base de datos externa; ambos microservicios usan H2 embebido.

Los servicios están expuestos en los puertos:

products-services: localhost:8080

inventory-services: localhost:8081